### PR TITLE
README.md update due to Debian/Ubuntu package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Avro phonetic implementation for Linux in IBus.
 On Ubuntu, and on Debian's *testing* and *unstable* releases, Avro phonetic
 is distributed through the `ibus-avro` package. To install it, simply do:
 
-		sudo apt install ibus-avro
+	sudo apt install ibus-avro
 
 On other Linux distros you can install the dependencies and build/install
 using the source code in this repository.
@@ -17,6 +17,7 @@ using the source code in this repository.
 		libibus-1.0-dev
 		automake
 		autoconf
+		make
 		gjs
 		ibus
 
@@ -24,7 +25,7 @@ using the source code in this repository.
 
     As root, do:
 
-		apt install git libibus-1.0-dev automake autoconf gjs ibus
+		apt install git libibus-1.0-dev automake autoconf make gjs ibus
 
     __For other linux distributions__
 

--- a/README.md
+++ b/README.md
@@ -3,27 +3,34 @@ Avro phonetic implementation for Linux in IBus.
 
 ## Installation
 
+On Ubuntu, and on Debian's *testing* and *unstable* releases, Avro phonetic
+is distributed through the `ibus-avro` package. To install it, simply do:
+
+		sudo apt install ibus-avro
+
+On other Linux distros you can install the dependencies and build/install
+using the source code in this repository.
+
 1. Open terminal/package manager and install following packages:
- 
-		git 
-		libibus-1.0-0
+
+		git
 		libibus-1.0-dev
-		ibus
-		automake 
+		automake
 		autoconf
 		gjs
-		gir1.2-gjsdbus-1.0
-		gir1.2-ibus-1.0
+		ibus
 
-    __For Ubuntu 12.04__
-    
-    	sudo apt-get install git ibus libibus-1.0-dev automake autoconf gjs gir1.2-gjsdbus-1.0 gir1.2-ibus-1.0
-	
-	
+    __For e.g. Debian 10 "buster"__
+
+    As root, do:
+
+		apt install git libibus-1.0-dev automake autoconf gjs ibus
+
     __For other linux distributions__
-    
+
     You'll need all related build tools like `automake`, `autoconf` etc...
-    and Latest __IBus__ from _git_ compiled with _gobject-introspection_ support enabled.
+    and to run it you need `ibus` and `gjs`. Use the list of packages above
+    as guidance, but please note that some packages may have other names.
 
 2. Now give the following commands step-by-step:
 


### PR DESCRIPTION
This an idea for updating `README.md`. I mark it as "WIP" for now, since the package is not yet in Debian testing.

I shortened the list of packages to install a bit, since `ibus` depends on `gir1.2-ibus-1.0` and the `libibus-1.0-0` and `gir1.2-gjsdbus-1.0` packages don't exist on more recent Debian/Ubuntu versions. Haven't tested though to which this applies to e.g. Fedora.

But the main message about the new package is there, and I'd say that this - if merged - wraps up and fixes #128.