### PR TITLE
add repology to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Avro phonetic implementation for Linux in IBus.
 
 ## Installation
 
+
+<a href="https://repology.org/project/ibus-avro/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/ibus-avro.svg" alt="Packaging status" align="right">
+</a>
+
 Ubuntu/Debian/Linux Mint
 ---
 


### PR DESCRIPTION
I added repology to README so that it shows all available official packages

![image](https://github.com/user-attachments/assets/3fa4b176-42e8-4e2e-b539-bc79465e4137)
